### PR TITLE
feat(SPI): IT data transmission.

### DIFF
--- a/drivers/Inc/spi.h
+++ b/drivers/Inc/spi.h
@@ -3,6 +3,7 @@
 
 #include "stm32f429zi.h"
 
+
 typedef enum  { SPI_Type_FullDuplex,  SPI_Type_HalfDuplex, SPI_Type_RxOnly} SPI_Config_Type; 
 typedef enum  { SPI_Mode_0, SPI_Mode_1, SPI_Mode_2, SPI_Mode_3 } SPI_Config_Mode;
 typedef enum { SPI_Hierarchy_Slave, SPI_Hierarchy_Master }SPI_Config_Hierarchy;
@@ -11,7 +12,8 @@ typedef enum { SPI_FrameFormat_MSBFirst,  SPI_FrameFormat_LSBFirst } SPI_Config_
 typedef enum { SPI_SSM_Disable, SPI_SSM_Enable } SPI_Config_SSM;
 typedef enum { SPI_DataFormat_8bit, SPI_DataFormat_16bit } SPI_Config_DataFormat;
 
-typedef enum { SPI_It_Disable}SPI_It_Mode;
+typedef enum { SPI_It_Disable, SPI_It_Enable}SPI_It_Mode;
+typedef enum { SPI_TxState_Ready, SPI_TxState_Busy} SPI_IT_TxState;
 
 typedef struct{
    SPI_Config_Type Type;
@@ -26,12 +28,22 @@ typedef struct{
 typedef struct{
   SPI_TypeDef *pSPIx;
   SPI_ConfigTypeDef Config;
-  SPI_It_Mode InterrupMode;
+  SPI_It_Mode InterruptMode;
+  uint32_t TxLen;
+  uint8_t *pTxBuffer;
+  SPI_IT_TxState TxState;
 }SPI_DriverTypeDef;
 
 DriverStatus SPI_Init(SPI_DriverTypeDef *pSPIDriver);
 
 void SPI_SendData(SPI_DriverTypeDef *pSPIDriver, uint8_t *pTxBuffer, uint32_t Len);
 
+DriverStatus SPI_SendDataIT(SPI_DriverTypeDef *pSPIDriver, uint8_t *pTxBuffer, uint32_t Len);
+
+void SPI_IRQ_Handling(SPI_DriverTypeDef *pSPIDriver);
+void SPI_IRQ_Control(uint8_t IRQNumber, EnableDisable EnOrDi);
+void SPI_IRQ_PriorityConfig(uint8_t IRQNumber, uint32_t IRQPriority);
+
+void SPI_CallbackTxCompleted(SPI_DriverTypeDef *pSPIDriver);
 
 #endif // !__SPI_H__

--- a/drivers/Inc/stm32f429zi.h
+++ b/drivers/Inc/stm32f429zi.h
@@ -3,6 +3,7 @@
 
 
 #include <stdint.h>
+#include <stddef.h>
 #include "stm32f429xx.h"
 
 // Clocks values definitions
@@ -13,7 +14,7 @@
 #define __vo volatile
 #define __weak __attribute__((weak))
 
-typedef enum{ERROR, OK}DriverStatus;
+typedef enum{ERROR, OK, BUSY }DriverStatus;
 typedef enum {DISABLE, ENABLE} EnableDisable;
 typedef enum {LOW, HIGH} PinLogicalLevel;
 typedef enum {FLAG_LOW, FLAG_HIGH} FlagStatus;

--- a/drivers/Src/gpio.c
+++ b/drivers/Src/gpio.c
@@ -1,5 +1,7 @@
 #include "gpio.h"
 
+// avoid multiple definitions
+
 static void GPIO_PeripheralClockControl(GPIO_TypeDef *GPIOx,
                                         EnableDisable EnorDi);
 static uint8_t GPIO_get_GPIOx_number(GPIO_TypeDef *GPIOx);
@@ -129,9 +131,9 @@ DriverStatus GPIO_Init(GPIO_DriverTypeDef *pGPIODriver) {
         LorH = pGPIODriver->Config.Number / 8;
         y = pGPIODriver->Config.Number % 8;
 
-        pGPIODriver->pGPIOx->AFR[LorH] &= ~(0x4 << (y * 4) );
+        pGPIODriver->pGPIOx->AFR[LorH] &= ~(0x4 << (y * 4));
         pGPIODriver->pGPIOx->AFR[LorH] |=
-            (pGPIODriver->Config.AlternateFunction << (y * 4) );
+            (pGPIODriver->Config.AlternateFunction << (y * 4));
     }
 
     return OK;

--- a/user/Src/it.c
+++ b/user/Src/it.c
@@ -4,3 +4,6 @@ void EXTI15_10_IRQHandler(void) {
     // Handling interruptions in Pin 13 (Built-in Button is PC13)
     GPIO_IRQ_Handling(13);
 }
+
+extern SPI_DriverTypeDef spi1;
+void SPI1_IRQHandler(void) { SPI_IRQ_Handling(&spi1); }

--- a/user/Src/main.c
+++ b/user/Src/main.c
@@ -5,17 +5,16 @@ void GPIO_initialization(void);
 void SPI_initialization(void);
 
 SPI_DriverTypeDef spi1;
+char msg[] = "Hello world";
 /*
  * This test will send data over SPI in blocking mode
  */
 
 int main(void) {
 
-    char msg[] = "Hello world";
-
     GPIO_initialization();
     SPI_initialization();
-    SPI_SendData(&spi1, (uint8_t *)msg, strlen(msg));
+    SPI_SendDataIT(&spi1, (uint8_t *)msg, strlen(msg));
     Test();
 
     while (1) {
@@ -77,12 +76,19 @@ void SPI_initialization(void) {
     spi1.Config.FrameFormat = SPI_FrameFormat_MSBFirst;
     spi1.Config.SSM = SPI_SSM_Disable;
     spi1.Config.DataFormat = SPI_DataFormat_8bit;
+    spi1.InterruptMode = SPI_It_Enable;
 
     SPI_Init(&spi1);
+    SPI_IRQ_Control(SPI1_IRQn, ENABLE);
+    SPI_IRQ_PriorityConfig(SPI1_IRQn, 15);
 }
 
 void Test(void) {
     for (uint8_t i = 0; i < 1; i++) {
         ;
     }
+}
+
+void SPI_CallbackTxCompleted(SPI_DriverTypeDef *pSPIDriver) {
+    SPI_SendDataIT(&spi1, (uint8_t *)msg, strlen(msg));
 }


### PR DESCRIPTION
Create the version of SPI transmission (Non blocking mode). With this, the following functions were added to work properly:

* SPI_IRQ_Handling: It checks if the arised interruption was due to TxE flag, if so it invokes SPI_IRQHandleTxe

* SPI_IRQHandleTxe: Sends one byte over the SPI peripheral, every time ensures they’re still some bytes to sent. If there are not more bytes to send, the it will call SPI_CloseTransmisison and then SPI_CallbackTxCompleted.

* SPI_CloseTransmission: Re-initialazes the struct that holds the pointer to the Tx data and sets the SPI again as avaiable and disables the SPI interruption.

* SPI_CallbackTxCompleted: Weak function to be overridden in the user layer if desired.

JIRA: SCRUM-18